### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,10 +9,10 @@
 Stats	KEYWORD1
 SimpleStats	KEYWORD1
 MovingAverage	KEYWORD1
-MovingStats     KEYWORD1
-AdaptiveNormalizer      KEYWORD1
-Normalizer  KEYWORD1
-MinMaxScaler    KEYWORD1
+MovingStats	KEYWORD1
+AdaptiveNormalizer	KEYWORD1
+Normalizer	KEYWORD1
+MinMaxScaler	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords